### PR TITLE
minor modification in Kmeans

### DIFF
--- a/R/fun.R
+++ b/R/fun.R
@@ -1,8 +1,8 @@
 mlKmeans <- function(X, y) {
 
-    X <- as.matrix(X)
+    X <- matrix(as.numeric(unlist(X)),nrow=nrow(X))
     y <- as.numeric(y)
 
-    .Call( "RcppMLPACK_kmeans", X, y, PACKAGE = "RcppMLPACK" )
+    .Call( "RcppMLPACK_kmeans", t(X), y, PACKAGE = "RcppMLPACK" )
 
 }


### PR DESCRIPTION
Hello,
         When I tried to apply "mlKmeans" on titanic titanic training datasets, I got this error:
`
data=read.csv("train.csv")
d=data[complete.cases(data),]
mlKmeans(d,2)
`
Error:
`
"Error: not compatible with requested type"
`
I think this error is due to factor variables in data as kmeans function in kmeans.cpp has armaa::mat data type. So I changed the mlKmeans function in fun.R to get numeric matrix. (Due to this I had to pass transpose of X ). Therefore,when passing data from R to MLPACK, a transpose will not be needed.  Would love to hear your feedback if PR is not as expected :).
Thanks.     
