### PR TITLE
update travis script, also switched to trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,34 +1,26 @@
-# Sample .travis.yml for R projects.
-#
-# See the r-travis repo and its wiki 
-#   https://github.com/craigcitro/r-travis/wiki
-#   https://github.com/eddelbuettel/r-travis/
+# Run Travis CI for R using https://eddelbuettel.github.io/r-travis/
 
 language: c
 
-env:
-  global:
-    - R_BUILD_ARGS="--no-build-vignettes --no-manual"
-    - R_CHECK_ARGS="--no-vignettes --no-manual"
+sudo: required
+
+dist: trusty
 
 before_install:
-  - curl -OL http://raw.github.com/craigcitro/r-travis/master/scripts/travis-tool.sh
-  - chmod 755 ./travis-tool.sh
-  - ./travis-tool.sh bootstrap
+  - curl -OLs http://eddelbuettel.github.io/r-travis/run.sh && chmod 0755 run.sh
+  - ./run.sh bootstrap
 
 install:
-  - ./travis-tool.sh install_aptget r-cran-runit
-  - ./travis-tool.sh install_r Rcpp
-  - ./travis-tool.sh install_r RcppArmadillo 
-  - ./travis-tool.sh install_github eddelbuettel/bh
-
-script: 
-  - ./travis-tool.sh run_tests
+  - ./run.sh install_aptget r-cran-rcpp r-cran-rcpparmadillo r-cran-bh r-cran-runit
+  
+script:
+  - ./run.sh run_tests
 
 after_failure:
-  - ./travis-tool.sh dump_logs
+  - ./run.sh dump_logs
 
 notifications:
   email:
     on_success: change
     on_failure: change
+    


### PR DESCRIPTION
This uses the most vanilla `.travis.yml` based on the R-Travis repo I maintain / extended -- I just set which four .deb packages to load for RUnit, Rcpp, RcppArmadillo and BH.

@coatless may not like it and prefer the new Travis scheme for R.  I don't care -- KK gets to pick.

But it works now and didn't before.  Net positive change good enough for me :)  